### PR TITLE
Fix code scanning alert no. 2: Server-side request forgery

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -23,6 +23,10 @@ const Form = ({ formId, petForm, forNewPet = true }) => {
   /* The PUT method edits an existing entry in the mongodb database. */
   const putData = async (form) => {
     const { id } = router.query
+    const isValidObjectId = /^[0-9a-fA-F]{24}$/.test(id);
+    if (!isValidObjectId) {
+      throw new Error('Invalid ID');
+    }
 
     try {
       const res = await fetch(`/api/pets/${id}`, {


### PR DESCRIPTION
Fixes [https://github.com/marmolleonardo/wth-devops-leon/security/code-scanning/2](https://github.com/marmolleonardo/wth-devops-leon/security/code-scanning/2)

To fix the problem, we need to validate and sanitize the `id` parameter before using it to construct the URL for the `fetch` request. One way to do this is to ensure that the `id` parameter matches a specific pattern or is included in an allow-list of valid IDs.

- Add a validation step to check if the `id` parameter is a valid MongoDB ObjectId.
- If the `id` is invalid, handle the error appropriately.
